### PR TITLE
Fix: instrumented tests by adding missing dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -143,6 +143,7 @@ dependencies {
 
     kspAndroidTest(libs.androidx.room.compiler)
 
+    debugImplementation(libs.androidx.test.monitor)
     debugImplementation(libs.ui.tooling)
     debugImplementation(libs.ui.test.manifest)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 androidGradlePlugin = "8.3.2"
-androidxActivityCompose = "1.8.2"
+androidxActivityCompose = "1.9.0"
 androidxAppcompat = "1.6.1"
 androidxBrowser = "1.8.0"
-androidxComposeBom = "2024.04.01"
+androidxComposeBom = "2024.05.00"
 androidxComposeMaterial3Alpha = "1.0.0-alpha06"
 androidXConstraintLayoutCompose = "1.0.1"
-androidxCore = "1.12.0"
+androidxCore = "1.13.1"
 androidxCameraX = "1.3.3"
 androidxCoreSplashscreen = "1.0.1"
 androidxDataStore = "1.1.1"
@@ -14,15 +14,16 @@ androidxHiltNavigationCompose = "1.2.0"
 androidxLifecycle = "2.7.0"
 androidxRoom = "2.6.1"
 androidxTestExtJunit = "1.1.5"
+androidxTestMonitor = "1.6.1"
 arrowKt = "1.2.4"
 desugaring = "2.0.4"
 espressoCore = "3.5.1"
-googleAccompanist = "0.32.0"
+googleAccompanist = "0.34.0"
 kotlin = "1.9.23"
 kotlinter = "4.2.0"
-kotlinxCoroutines = "1.7.3"
+kotlinxCoroutines = "1.8.0"
 junit = "4.13.2"
-hilt = "2.49"
+hilt = "2.51"
 ksp = "1.9.23-1.0.20"
 mlkitBarcodeScanning = "17.2.0"
 protobuf = "3.25.2"
@@ -65,6 +66,7 @@ androidx-room = { group = "androidx.room", name = "room-runtime", version.ref = 
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "androidxRoom" }
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "androidxRoom" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTestExtJunit" }
+androidx-test-monitor = { group = "androidx.test", name = "monitor", version.ref="androidxTestMonitor" }
 arrow-optics = { group = "io.arrow-kt", name = "arrow-optics", version.ref = "arrowKt" }
 arrow-optics-ksp = { group = "io.arrow-kt", name = "arrow-optics-ksp-plugin", version.ref = "arrowKt" }
 desugaring-jdk = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugaring" }


### PR DESCRIPTION
The following error was occuring in emulator:
`java.lang.NoClassDefFoundError: Failed resolution of: Landroidx/test/platform/io/PlatformTestStorageRegistry;`

For some reason it didn't happen before, but adding `androidx.test.monitor` dependency solved it.