### PR TITLE
Bugfix: Small issues in Generating

### DIFF
--- a/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/generate/navigation/GenerateQRCodeNavigation.kt
+++ b/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/generate/navigation/GenerateQRCodeNavigation.kt
@@ -5,6 +5,7 @@ import android.graphics.Bitmap
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -53,7 +54,9 @@ private fun GenerateQRCodeCoordinator(
     val context = LocalContext.current
     val uiState: GenerateQRCodeUIState by viewModel.uiState.collectAsStateWithLifecycle()
     (savedStateHandle.get<QRCodeComposeXFormat>(CODE_FORMAT_KEY))?.let {
-        viewModel.onNewAction(GenerateQRCodeUIAction.Customize(options = QRCodeCustomizationOptions(it)))
+        LaunchedEffect(key1 = it) {
+            viewModel.onNewAction(GenerateQRCodeUIAction.Customize(options = QRCodeCustomizationOptions(it)))
+        }
     }
     var currentQRCodeBitmap: Bitmap? by remember { mutableStateOf(null) }
     val saveImageLauncher =

--- a/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/generate/presentation/GenerateQRCodeScreen.kt
+++ b/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/generate/presentation/GenerateQRCodeScreen.kt
@@ -3,14 +3,19 @@ package com.pedroid.qrcodecompose.androidapp.features.generate.presentation
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -53,6 +58,7 @@ import com.pedroid.qrcodecompose.androidapp.features.generate.navigation.Generat
 import com.pedroid.qrcodecomposelib.common.QRCodeComposeXFormat
 
 // region screen composables
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun GenerateQRCodeScreen(
     state: GenerateQRCodeContentState,
@@ -64,6 +70,8 @@ fun GenerateQRCodeScreen(
         modifier =
             Modifier
                 .fillMaxSize()
+                .windowInsetsPadding(WindowInsets.safeDrawing)
+                .imePadding()
                 .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -281,7 +289,7 @@ private fun QRCodeActionButtons(actionListeners: GenerateQRCodeActionListeners =
         Icon(
             modifier = Modifier.size(Dimens.iconButtonSize),
             imageVector = Icons.Outlined.SaveAlt,
-            contentDescription = stringResource(id = R.string.action_open),
+            contentDescription = stringResource(id = R.string.action_save_to_file),
         )
     }
     Spacer(modifier = Modifier.size(Dimens.spacingMedium))

--- a/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/generate/presentation/GenerateQRCodeViewModel.kt
+++ b/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/generate/presentation/GenerateQRCodeViewModel.kt
@@ -98,7 +98,6 @@ class GenerateQRCodeViewModel
                         savedStateHandle.updateState {
                             it.copy {
                                 GenerateQRCodeUIState.content.inputText.set(action.text)
-                                GenerateQRCodeUIState.content.inputErrorMessage.set("")
                             }
                         }
                         action
@@ -110,7 +109,10 @@ class GenerateQRCodeViewModel
                     // only update qrcode to generate if user as stopped typing for a small interval
                     logger.debug(LOG_TAG, "Update QR code to generate based on action $action")
                     savedStateHandle.updateState {
-                        GenerateQRCodeUIState.content.generating.qrCodeText.set(it, action.text)
+                        it.copy {
+                            GenerateQRCodeUIState.content.generating.qrCodeText.set(action.text)
+                            GenerateQRCodeUIState.content.inputErrorMessage.set("")
+                        }
                     }
                 }
                 .launchIn(viewModelScope)
@@ -134,7 +136,10 @@ class GenerateQRCodeViewModel
                         null
                     }
                     actionWithCurrentContent.actionComplete?.status != ActionStatus.SUCCESS -> null
-                    generatingContent == actionWithCurrentContent.code -> null
+                    generatingContent == actionWithCurrentContent.code -> {
+                        resetActionComplete(actionWithCurrentContent)
+                        null
+                    }
                     else -> GeneratedCodeWithAction(generatingContent, actionWithCurrentContent.actionComplete)
                 }
             }

--- a/app/src/test/java/com/pedroid/qrcodecompose/androidapp/features/generate/presentation/GenerateQRCodeViewModelTest.kt
+++ b/app/src/test/java/com/pedroid/qrcodecompose/androidapp/features/generate/presentation/GenerateQRCodeViewModelTest.kt
@@ -16,6 +16,7 @@ import com.pedroid.qrcodecompose.androidapp.features.settings.domain.GenerateSet
 import com.pedroid.qrcodecompose.androidapp.features.settings.domain.HistorySavePreferences
 import com.pedroid.qrcodecompose.androidapp.features.settings.domain.SettingsReadOnlyRepository
 import com.pedroid.qrcodecomposelib.common.QRCodeComposeXFormat
+import com.pedroid.qrcodecomposelib.generate.QRCodeComposeXNotCompliantWithFormatException
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -337,6 +338,16 @@ class GenerateQRCodeViewModelTest {
                 awaitItem().temporaryMessage.assertHasError()
                 sut.onNewAction(GenerateQRCodeUIAction.TmpMessageShown)
                 assertTrue(awaitItem().temporaryMessage == null)
+            }
+        }
+
+    @Test
+    fun `given generate error actions for invalid format is sent, state errorMessageKey is updated`() =
+        runTest {
+            sut.uiState.test {
+                awaitItem() // initial state
+                sut.onNewAction(GenerateQRCodeUIAction.GenerateErrorReceived(QRCodeComposeXNotCompliantWithFormatException()))
+                assertTrue(awaitItem().content.inputErrorMessage.isNotEmpty())
             }
         }
 


### PR DESCRIPTION
- When inputting text for Formats with restrictions (e.g. UPC-E), an error would be emitted mistakenly -> https://github.com/pedro-mgb/mini_qr_code/assets/47814970/371b1594-047b-4d8d-8648-82b078b93667

- The UI wasn't being pushed up properly when keyboard is opening, due to a recent edge-to-edge change

- Sometimes a QR Code was being saved to history just by changing the text.

