### PR TITLE
Refactor: Type-Safe Compose Navigation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -108,6 +108,7 @@ dependencies {
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.room)
     implementation(libs.androidx.room.ktx)
     implementation(libs.arrow.optics)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.hilt)
     alias(libs.plugins.kotlinter)
     alias(libs.plugins.kotlin.parcelize)
+    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
     alias(libs.plugins.protobuf)
 }
@@ -116,6 +117,7 @@ dependencies {
     implementation(libs.hilt.android)
     implementation(libs.hilt.android.testing)
     implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.kotlinx.serialization.json)
     implementation(libs.protobuf.kotlin.lite)
     // region test utils
     implementation(libs.junit)

--- a/app/src/main/java/com/pedroid/qrcodecompose/androidapp/core/navigation/CustomNavTypes.kt
+++ b/app/src/main/java/com/pedroid/qrcodecompose/androidapp/core/navigation/CustomNavTypes.kt
@@ -1,0 +1,34 @@
+package com.pedroid.qrcodecompose.androidapp.core.navigation
+
+import android.os.Build
+import android.os.Bundle
+import androidx.navigation.NavType
+import com.pedroid.qrcodecomposelib.common.QRCodeComposeXFormat
+
+/**
+ * Necessary because by default Jetpack Navigation only supports specific navtypes
+ *
+ * Creidts: https://github.com/ioannisa/TypeSafeComposeNavigation/blob/main/app/src/main/java/eu/anifantakis/navdemo/navigation/NavRoute.kt#L22
+ */
+fun NavType.Companion.ofQRCodeComposeXFormat(): NavType<QRCodeComposeXFormat> {
+    return object : NavType<QRCodeComposeXFormat>(isNullableAllowed = false) {
+        override fun get(
+            bundle: Bundle,
+            key: String,
+        ): QRCodeComposeXFormat? =
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.TIRAMISU) {
+                @Suppress("DEPRECATION")
+                bundle.getSerializable(key) as? QRCodeComposeXFormat
+            } else {
+                bundle.getSerializable(key, QRCodeComposeXFormat::class.java)
+            }
+
+        override fun parseValue(value: String): QRCodeComposeXFormat = QRCodeComposeXFormat.valueOf(value)
+
+        override fun put(
+            bundle: Bundle,
+            key: String,
+            value: QRCodeComposeXFormat,
+        ) = bundle.putSerializable(key, value)
+    }
+}

--- a/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/generate/navigation/GenerateQRCodeNavigation.kt
+++ b/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/generate/navigation/GenerateQRCodeNavigation.kt
@@ -32,14 +32,16 @@ import com.pedroid.qrcodecompose.androidapp.features.generate.presentation.Gener
 import com.pedroid.qrcodecompose.androidapp.features.generate.presentation.GenerateQRCodeViewModel
 import com.pedroid.qrcodecomposelib.common.QRCodeComposeXFormat
 import com.pedroid.qrcodecomposelib.generate.QRCodeGenerateResult
+import kotlinx.serialization.Serializable
 
-const val GENERATE_ROUTE = "GENERATE_QR_CODE_ROUTE"
+@Serializable
+data object GenerateQRCodeHomeRoute
 
 fun NavGraphBuilder.generateQRCodeRoute(
     navigationListeners: GenerateQRCodeHomeNavigationListeners,
     largeScreen: Boolean = false,
 ) {
-    composable(route = GENERATE_ROUTE) {
+    composable<GenerateQRCodeHomeRoute> {
         GenerateQRCodeCoordinator(navigationListeners, largeScreen, it.savedStateHandle)
     }
 }
@@ -142,5 +144,5 @@ private fun Context.getNameFromFormat(uiState: GenerateQRCodeUIState): String =
     this.getString(uiState.content.generating.format.titleStringId)
 
 fun NavController.navigateToGenerateQRCodeInfo(navOptions: NavOptions? = null) {
-    this.navigate(GENERATE_ROUTE, navOptions)
+    this.navigate(GenerateQRCodeHomeRoute, navOptions)
 }

--- a/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/generate/navigation/customize/format/QRCodeFormatSelectionNavigation.kt
+++ b/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/generate/navigation/customize/format/QRCodeFormatSelectionNavigation.kt
@@ -1,41 +1,38 @@
 package com.pedroid.qrcodecompose.androidapp.features.generate.navigation.customize.format
 
+import android.os.Parcelable
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
-import androidx.navigation.navArgument
+import androidx.navigation.toRoute
+import com.pedroid.qrcodecompose.androidapp.core.navigation.ofQRCodeComposeXFormat
 import com.pedroid.qrcodecompose.androidapp.features.generate.navigation.customize.QRCodeSelectFormatListeners
 import com.pedroid.qrcodecompose.androidapp.features.generate.presentation.customize.format.QRCodeFormatSelectionScreen
 import com.pedroid.qrcodecomposelib.common.QRCodeComposeXFormat
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.Serializable
+import kotlin.reflect.typeOf
 
-private const val ROUTE_START = "SELECT_CODE_FORMAT_ROUTE"
-private const val ARGUMENT_KEY = "selectedFormat"
-const val SELECT_FORMAT_ROUTE = "$ROUTE_START/{$ARGUMENT_KEY}"
-
-private val defaultFormat = QRCodeComposeXFormat.QR_CODE.name
-private val navArguments =
-    listOf(
-        navArgument(ARGUMENT_KEY) {
-            type = NavType.StringType
-            defaultValue = defaultFormat
-        },
-    )
+@Serializable
+@Parcelize
+data class SelectFormatRoute(
+    val currentFormat: QRCodeComposeXFormat,
+) : Parcelable
 
 fun NavGraphBuilder.generateQRCodeSelectFormatRoute(
     navigationListeners: QRCodeSelectFormatListeners,
     largeScreen: Boolean = false,
 ) {
-    composable(
-        SELECT_FORMAT_ROUTE,
-        navArguments,
+    composable<SelectFormatRoute>(
+        typeMap = mapOf(typeOf<QRCodeComposeXFormat>() to NavType.ofQRCodeComposeXFormat()),
     ) {
+        val route = it.toRoute<SelectFormatRoute>()
         QRCodeFormatSelectionCoordinator(
             navigationListeners = navigationListeners,
-            selectedFormat = it.arguments?.getString(ARGUMENT_KEY),
+            selectedFormat = route.currentFormat,
             largeScreen = largeScreen,
         )
     }
@@ -44,31 +41,19 @@ fun NavGraphBuilder.generateQRCodeSelectFormatRoute(
 @Composable
 fun QRCodeFormatSelectionCoordinator(
     navigationListeners: QRCodeSelectFormatListeners,
-    selectedFormat: String?,
+    selectedFormat: QRCodeComposeXFormat,
     largeScreen: Boolean = false,
 ) {
-    val qrcodeComposeXFormat =
-        remember {
-            QRCodeComposeXFormat.entries.firstOrNull {
-                it.name == selectedFormat
-            }
-        }
-    if (qrcodeComposeXFormat == null) {
-        // if the argument arrives as null, most likely it is a result of some error in the code
-        //  rather than crashing the app, we are silently closing the screen
-        navigationListeners.onCancel()
-    } else {
-        QRCodeFormatSelectionScreen(
-            selectedFormat = qrcodeComposeXFormat,
-            actionListeners = navigationListeners,
-            largeScreen = largeScreen,
-        )
-    }
+    QRCodeFormatSelectionScreen(
+        selectedFormat = selectedFormat,
+        actionListeners = navigationListeners,
+        largeScreen = largeScreen,
+    )
 }
 
 fun NavController.navigateToQRCodeSelectFormat(
     navOptions: NavOptions? = null,
     format: QRCodeComposeXFormat,
 ) {
-    this.navigate("$ROUTE_START/$format", navOptions)
+    this.navigate(SelectFormatRoute(format), navOptions)
 }

--- a/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/history/domain/HistoryEntry.kt
+++ b/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/history/domain/HistoryEntry.kt
@@ -5,7 +5,6 @@ import java.time.Instant
 
 // when creating a new entry in history, to avoid specifying an id, use this new one
 const val ID_NEW_ENTRY: Long = 0L
-const val ID_INVALID: Long = -1L
 
 sealed class HistoryEntry(
     open val uid: Long,

--- a/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/history/navigation/QRCodeHistoryListNavigation.kt
+++ b/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/history/navigation/QRCodeHistoryListNavigation.kt
@@ -22,11 +22,13 @@ import com.pedroid.qrcodecompose.androidapp.features.history.presentation.Histor
 import com.pedroid.qrcodecompose.androidapp.features.history.presentation.HistoryListViewModel
 import com.pedroid.qrcodecompose.androidapp.features.history.presentation.HistoryMoreInfoBottomSheet
 import com.pedroid.qrcodecompose.androidapp.features.history.presentation.delete.HistoryDeleteConfirmationDialog
+import kotlinx.serialization.Serializable
 
-const val HISTORY_LIST_ROUTE = "QR_CODE_HISTORY_LIST_ROUTE"
+@Serializable
+data object HistoryListRoute
 
 fun NavGraphBuilder.historyListRoute(navigationListeners: HistoryListNavigationListeners) {
-    composable(route = HISTORY_LIST_ROUTE) {
+    composable<HistoryListRoute> {
         HistoryListCoordinator(navigationListeners, it.savedStateHandle)
     }
 }
@@ -123,5 +125,5 @@ fun HistoryListDeleteItemsDialog(
 }
 
 fun NavController.navigateToQRCodeHistoryList(navOptions: NavOptions? = null) {
-    this.navigate(HISTORY_LIST_ROUTE, navOptions)
+    this.navigate(HistoryListRoute, navOptions)
 }

--- a/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/history/navigation/detail/QRCodeHistoryDetailNavigation.kt
+++ b/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/history/navigation/detail/QRCodeHistoryDetailNavigation.kt
@@ -15,9 +15,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
-import androidx.navigation.NavType
 import androidx.navigation.compose.composable
-import androidx.navigation.navArgument
+import androidx.navigation.toRoute
 import com.pedroid.qrcodecompose.androidapp.R
 import com.pedroid.qrcodecompose.androidapp.core.domain.ActionStatus
 import com.pedroid.qrcodecompose.androidapp.core.domain.QRAppActions
@@ -26,7 +25,6 @@ import com.pedroid.qrcodecompose.androidapp.core.presentation.copyImageToClipboa
 import com.pedroid.qrcodecompose.androidapp.core.presentation.copyTextToClipboard
 import com.pedroid.qrcodecompose.androidapp.core.presentation.shareImageToAnotherApp
 import com.pedroid.qrcodecompose.androidapp.core.presentation.shareTextToAnotherApp
-import com.pedroid.qrcodecompose.androidapp.features.history.domain.ID_INVALID
 import com.pedroid.qrcodecompose.androidapp.features.history.presentation.delete.HistoryDeleteConfirmationDialog
 import com.pedroid.qrcodecompose.androidapp.features.history.presentation.detail.HistoryDetailScreen
 import com.pedroid.qrcodecompose.androidapp.features.history.presentation.detail.HistoryDetailUIAction
@@ -35,33 +33,24 @@ import com.pedroid.qrcodecompose.androidapp.features.history.presentation.detail
 import com.pedroid.qrcodecompose.androidapp.features.history.presentation.detail.HistoryDetailViewModelFactory
 import com.pedroid.qrcodecomposelib.common.QRCodeComposeXFormat
 import com.pedroid.qrcodecomposelib.generate.QRCodeGenerateResult
+import kotlinx.serialization.Serializable
 
-private const val ROUTE_START = "QR_CODE_HISTORY_DETAIL_ROUTE"
-private const val ARGUMENT_KEY = "historyId"
-const val HISTORY_DETAIL_ROUTE = "$ROUTE_START/{$ARGUMENT_KEY}"
-
-private val navArguments =
-    listOf(
-        navArgument(ARGUMENT_KEY) {
-            type = NavType.LongType
-            defaultValue = ID_INVALID
-        },
-    )
+@Serializable
+data class HistoryDetailRoute(val uid: Long)
 
 fun NavGraphBuilder.historyDetailRoute(
     navigationListeners: HistoryDetailNavigationListeners,
     largeScreen: Boolean,
 ) {
-    composable(route = HISTORY_DETAIL_ROUTE, navArguments) {
+    composable<HistoryDetailRoute> {
+        val route = it.toRoute<HistoryDetailRoute>()
         HistoryDetailCoordinator(
             navigationListeners = navigationListeners,
             largeScreen = largeScreen,
             viewModel =
                 hiltViewModel<HistoryDetailViewModel, HistoryDetailViewModelFactory>(
                     creationCallback = { factory ->
-                        factory.create(
-                            entryUid = it.arguments?.getLong(ARGUMENT_KEY, ID_INVALID) ?: ID_INVALID,
-                        )
+                        factory.create(entryUid = route.uid)
                     },
                 ),
         )
@@ -168,5 +157,5 @@ fun NavController.navigateToHistoryDetail(
     navOptions: NavOptions? = null,
     uid: Long,
 ) {
-    this.navigate("$ROUTE_START/$uid", navOptions)
+    this.navigate(HistoryDetailRoute(uid), navOptions)
 }

--- a/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/scan/navigation/ScanQRCodeCameraNavigation.kt
+++ b/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/scan/navigation/ScanQRCodeCameraNavigation.kt
@@ -17,14 +17,16 @@ import com.pedroid.qrcodecompose.androidapp.features.scan.presentation.QRCodeCam
 import com.pedroid.qrcodecompose.androidapp.features.scan.presentation.QRCodeCameraUIState
 import com.pedroid.qrcodecompose.androidapp.features.scan.presentation.ScanQRCodeCameraScreen
 import com.pedroid.qrcodecompose.androidapp.features.scan.presentation.ScanQRCodeCameraViewModel
+import kotlinx.serialization.Serializable
 
-const val SCAN_CAMERA_READER_ROUTE = "SCAN_QR_CODE_CAMERA_READER_ROUTE"
+@Serializable
+data object ScanCameraReaderRoute
 
 fun NavGraphBuilder.scanQRCodeCameraRoute(
     navigationListeners: ScanQRCodeCameraNavigationListeners,
     largeScreen: Boolean,
 ) {
-    composable(route = SCAN_CAMERA_READER_ROUTE) {
+    composable<ScanCameraReaderRoute> {
         ScanQRCodeCameraCoordinator(navigationListeners, largeScreen)
     }
 }
@@ -74,5 +76,5 @@ fun NavController.navigateToScanQRCodeCamera(
             launchSingleTop = true
         },
 ) {
-    this.navigate(SCAN_CAMERA_READER_ROUTE, navOptions)
+    this.navigate(ScanCameraReaderRoute, navOptions)
 }

--- a/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/scan/navigation/ScanQRCodeInfoNavigation.kt
+++ b/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/scan/navigation/ScanQRCodeInfoNavigation.kt
@@ -25,14 +25,16 @@ import com.pedroid.qrcodecompose.androidapp.features.scan.presentation.QRCodeInf
 import com.pedroid.qrcodecompose.androidapp.features.scan.presentation.ScanQRCodeInfoScreen
 import com.pedroid.qrcodecompose.androidapp.features.scan.presentation.ScanQRCodeInfoViewModel
 import com.pedroid.qrcodecompose.androidapp.features.settings.presentation.openUrl
+import kotlinx.serialization.Serializable
 
-const val SCAN_ROUTE = "SCAN_QR_CODE_ROUTE"
+@Serializable
+data object ScanQRCodeInfoRoute
 
 fun NavGraphBuilder.scanQRCodeInfoRoute(
     navigationListeners: ScanQRCodeInfoNavigationListeners,
     largeScreen: Boolean,
 ) {
-    composable(route = SCAN_ROUTE) {
+    composable<ScanQRCodeInfoRoute> {
         ScanCodeHomeCoordinator(navigationListeners, largeScreen, it.savedStateHandle)
     }
 }
@@ -101,5 +103,5 @@ private fun ScanCodeHomeCoordinator(
 }
 
 fun NavController.navigateToScanQRCodeInfo(navOptions: NavOptions? = null) {
-    this.navigate(SCAN_ROUTE, navOptions)
+    this.navigate(ScanQRCodeInfoRoute, navOptions)
 }

--- a/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/scan/navigation/fromfile/ScanQRCodeFromFileNavigation.kt
+++ b/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/scan/navigation/fromfile/ScanQRCodeFromFileNavigation.kt
@@ -27,8 +27,11 @@ import com.pedroid.qrcodecompose.androidapp.features.scan.presentation.fromfile.
 import com.pedroid.qrcodecomposelib.scan.QRCodeFileAnalyzer
 import com.pedroid.qrcodecomposelib.scan.QRCodeScanResult
 import com.pedroid.qrcodecomposelibmlkit.MLKitImageAnalyzer
+import kotlinx.serialization.Serializable
 
-const val SCAN_FILE_READER_ROUTE = "SCAN_QR_CODE_FILE_READER_ROUTE"
+@Serializable
+data object ScanFileReaderRoute
+
 private val imagesOnlyPicker =
     PickVisualMediaRequest(
         mediaType = ActivityResultContracts.PickVisualMedia.ImageOnly,
@@ -38,7 +41,7 @@ fun NavGraphBuilder.scanQRCodeFromFileRoute(
     navigationListeners: ScanQRCodeCameraNavigationListeners,
     largeScreen: Boolean,
 ) {
-    composable(route = SCAN_FILE_READER_ROUTE) {
+    composable<ScanFileReaderRoute> {
         ScanQRCodeFromFileCoordinator(navigationListeners, largeScreen)
     }
 }
@@ -138,5 +141,5 @@ fun NavController.navigateToScanQRCodeFromFile(
             launchSingleTop = true
         },
 ) {
-    this.navigate(SCAN_FILE_READER_ROUTE, navOptions)
+    this.navigate(ScanFileReaderRoute, navOptions)
 }

--- a/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/settings/navigation/SettingsMainNavigation.kt
+++ b/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/settings/navigation/SettingsMainNavigation.kt
@@ -19,12 +19,15 @@ import com.pedroid.qrcodecompose.androidapp.features.settings.presentation.Setti
 import com.pedroid.qrcodecompose.androidapp.features.settings.presentation.SettingsMainUIState
 import com.pedroid.qrcodecompose.androidapp.features.settings.presentation.SettingsMainViewModel
 import com.pedroid.qrcodecompose.androidapp.features.settings.presentation.SettingsOptionSelectionBottomSheet
+import kotlinx.serialization.Serializable
 
-const val SETTINGS_ROUTE = "APP_SETTINGS_ROUTE"
+@Serializable
+data object SettingMainRoute
+
 private const val PLAY_STORE_URL = "https://play.google.com/store/apps/details?id=com.pedroid.qrcodecompose.androidapp"
 
 fun NavGraphBuilder.settingsMainRoute(navigationListeners: SettingsMainNavigationListeners) {
-    composable(route = SETTINGS_ROUTE) {
+    composable<SettingMainRoute> {
         SettingsMainCoordinator(navigationListeners)
     }
 }
@@ -79,5 +82,5 @@ private fun SettingsMainCoordinator(
 }
 
 fun NavController.navigateToMainSettings(navOptions: NavOptions? = null) {
-    this.navigate(SETTINGS_ROUTE, navOptions)
+    this.navigate(SettingMainRoute, navOptions)
 }

--- a/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/settings/navigation/about/SettingsAboutAppNavigation.kt
+++ b/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/settings/navigation/about/SettingsAboutAppNavigation.kt
@@ -17,6 +17,10 @@ import com.pedroid.qrcodecompose.androidapp.features.settings.presentation.about
 import com.pedroid.qrcodecompose.androidapp.features.settings.presentation.about.SettingsAboutAppUIState
 import com.pedroid.qrcodecompose.androidapp.features.settings.presentation.about.SettingsAboutAppViewModel
 import com.pedroid.qrcodecompose.androidapp.features.settings.presentation.openUrl
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object AboutAppRoute
 
 private const val GITHUB_REPOSITORY = "https://github.com/pedro-mgb/mini_qr_code"
 private const val PRIVACY_POLICY =
@@ -24,10 +28,8 @@ private const val PRIVACY_POLICY =
         "blob/main/docs/legal/privacy-policy-en.md#mini-qr-code---privacy-policy"
 private const val MORE_APPS_URL = "https://play.google.com/store/apps/developer?id=pedroid04"
 
-const val ABOUT_APP_ROUTE = "ABOUT_APP_ROUTE"
-
 fun NavGraphBuilder.settingsAboutAppRoute(navigationListeners: SettingsAboutAppNavigationListeners) {
-    composable(ABOUT_APP_ROUTE) {
+    composable<AboutAppRoute> {
         SettingsAboutAppCoordinator(navigationListeners = navigationListeners)
     }
 }
@@ -68,5 +70,5 @@ private fun SettingsAboutAppCoordinator(
 }
 
 fun NavController.navigateToSettingsAboutApp(navOptions: NavOptions? = null) {
-    this.navigate(ABOUT_APP_ROUTE, navOptions)
+    this.navigate(AboutAppRoute, navOptions)
 }

--- a/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/settings/navigation/contact/SettingsContactNavigation.kt
+++ b/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/settings/navigation/contact/SettingsContactNavigation.kt
@@ -16,13 +16,16 @@ import com.pedroid.qrcodecompose.androidapp.features.settings.presentation.about
 import com.pedroid.qrcodecompose.androidapp.features.settings.presentation.about.SettingsAboutAppViewModel
 import com.pedroid.qrcodecompose.androidapp.features.settings.presentation.contact.SettingsContactScreen
 import com.pedroid.qrcodecompose.androidapp.features.settings.presentation.openUrl
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object ContactRoute
 
 private const val CONTACT_EMAIL = "pedroid.apps.contact@gmail.com"
 private const val GITHUB_ISSUE_URL = "https://github.com/pedro-mgb/mini_qr_code/issues/new"
-const val CONTACT_ROUTE = "CONTACT_DEVELOPER_ROUTE"
 
 fun NavGraphBuilder.settingsContactRoute(navigationListeners: SettingsContactNavigationListeners) {
-    composable(CONTACT_ROUTE) {
+    composable<ContactRoute> {
         SettingsContactCoordinator(navigationListeners = navigationListeners)
     }
 }
@@ -60,5 +63,5 @@ private fun SettingsContactCoordinator(
 }
 
 fun NavController.navigateToSettingsContact(navOptions: NavOptions? = null) {
-    this.navigate(CONTACT_ROUTE, navOptions)
+    this.navigate(ContactRoute, navOptions)
 }

--- a/app/src/main/java/com/pedroid/qrcodecompose/androidapp/home/navigation/HomeDestinationItem.kt
+++ b/app/src/main/java/com/pedroid/qrcodecompose/androidapp/home/navigation/HomeDestinationItem.kt
@@ -8,15 +8,17 @@ import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.pedroid.qrcodecompose.androidapp.R
 import com.pedroid.qrcodecompose.androidapp.designsystem.icons.filled.ScanQRCode
-import com.pedroid.qrcodecompose.androidapp.features.generate.navigation.GENERATE_ROUTE
-import com.pedroid.qrcodecompose.androidapp.features.generate.navigation.customize.format.SELECT_FORMAT_ROUTE
-import com.pedroid.qrcodecompose.androidapp.features.history.navigation.HISTORY_LIST_ROUTE
-import com.pedroid.qrcodecompose.androidapp.features.history.navigation.detail.HISTORY_DETAIL_ROUTE
-import com.pedroid.qrcodecompose.androidapp.features.scan.navigation.SCAN_CAMERA_READER_ROUTE
-import com.pedroid.qrcodecompose.androidapp.features.scan.navigation.SCAN_ROUTE
-import com.pedroid.qrcodecompose.androidapp.features.settings.navigation.SETTINGS_ROUTE
-import com.pedroid.qrcodecompose.androidapp.features.settings.navigation.about.ABOUT_APP_ROUTE
-import com.pedroid.qrcodecompose.androidapp.features.settings.navigation.contact.CONTACT_ROUTE
+import com.pedroid.qrcodecompose.androidapp.features.generate.navigation.GenerateQRCodeHomeRoute
+import com.pedroid.qrcodecompose.androidapp.features.generate.navigation.customize.format.SelectFormatRoute
+import com.pedroid.qrcodecompose.androidapp.features.history.navigation.HistoryListRoute
+import com.pedroid.qrcodecompose.androidapp.features.history.navigation.detail.HistoryDetailRoute
+import com.pedroid.qrcodecompose.androidapp.features.scan.navigation.ScanCameraReaderRoute
+import com.pedroid.qrcodecompose.androidapp.features.scan.navigation.ScanQRCodeInfoRoute
+import com.pedroid.qrcodecompose.androidapp.features.scan.navigation.fromfile.ScanFileReaderRoute
+import com.pedroid.qrcodecompose.androidapp.features.settings.navigation.SettingMainRoute
+import com.pedroid.qrcodecompose.androidapp.features.settings.navigation.about.AboutAppRoute
+import com.pedroid.qrcodecompose.androidapp.features.settings.navigation.contact.ContactRoute
+import kotlin.reflect.KClass
 
 /**
  * enum containing items used in bottom navigation / navigation rail
@@ -25,51 +27,52 @@ import com.pedroid.qrcodecompose.androidapp.features.settings.navigation.contact
 sealed class HomeDestinationItem(
     @StringRes val itemTextId: Int,
     val itemIcon: ImageVector,
-    val routeLabel: String,
-    val encompassingRoutes: List<String> = listOf(routeLabel),
+    val routeClass: KClass<*>,
+    val encompassingRoutes: List<KClass<*>> = listOf(routeClass),
 ) {
     data object Scan : HomeDestinationItem(
         itemTextId = R.string.bottom_navigation_item_scan,
         itemIcon = Icons.Filled.ScanQRCode,
-        routeLabel = SCAN_ROUTE,
+        routeClass = ScanQRCodeInfoRoute::class,
         encompassingRoutes =
             listOf(
-                SCAN_ROUTE,
-                SCAN_CAMERA_READER_ROUTE,
+                ScanQRCodeInfoRoute::class,
+                ScanCameraReaderRoute::class,
+                ScanFileReaderRoute::class,
             ),
     )
 
     data object Generate : HomeDestinationItem(
         itemTextId = R.string.bottom_navigation_item_generate,
         itemIcon = Icons.Filled.AddCircle,
-        routeLabel = GENERATE_ROUTE,
+        routeClass = GenerateQRCodeHomeRoute::class,
         encompassingRoutes =
             listOf(
-                GENERATE_ROUTE,
-                SELECT_FORMAT_ROUTE,
+                GenerateQRCodeHomeRoute::class,
+                SelectFormatRoute::class,
             ),
     )
 
     data object History : HomeDestinationItem(
         itemTextId = R.string.bottom_navigation_item_history,
         itemIcon = Icons.Filled.DateRange,
-        routeLabel = HISTORY_LIST_ROUTE,
+        routeClass = HistoryListRoute::class,
         encompassingRoutes =
             listOf(
-                HISTORY_LIST_ROUTE,
-                HISTORY_DETAIL_ROUTE,
+                HistoryListRoute::class,
+                HistoryDetailRoute::class,
             ),
     )
 
     data object Settings : HomeDestinationItem(
         itemTextId = R.string.bottom_navigation_item_settings,
         itemIcon = Icons.Rounded.Settings,
-        routeLabel = SETTINGS_ROUTE,
+        routeClass = SettingMainRoute::class,
         encompassingRoutes =
             listOf(
-                SETTINGS_ROUTE,
-                CONTACT_ROUTE,
-                ABOUT_APP_ROUTE,
+                SettingMainRoute::class,
+                ContactRoute::class,
+                AboutAppRoute::class,
             ),
     )
 
@@ -84,4 +87,11 @@ sealed class HomeDestinationItem(
     }
 }
 
-val defaultStartRoute: String = HomeDestinationItem.Scan.routeLabel
+val defaultStartRoute: KClass<*> = HomeDestinationItem.Scan.routeClass
+
+fun HomeDestinationItem.encompassesRoute(route: String?): Boolean =
+    route?.let { r ->
+        encompassingRoutes.map { it.simpleName ?: "" }.any {
+            r.contains(it, ignoreCase = true)
+        }
+    } ?: false

--- a/app/src/main/java/com/pedroid/qrcodecompose/androidapp/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/pedroid/qrcodecompose/androidapp/home/navigation/HomeNavigation.kt
@@ -10,7 +10,7 @@ import com.pedroid.qrcodecompose.androidapp.features.scan.navigation.navigateToS
 import com.pedroid.qrcodecompose.androidapp.features.settings.navigation.navigateToMainSettings
 
 fun NavController.navigateToHomeDestinationItem(item: HomeDestinationItem) {
-    if (currentBackStackEntry?.destination?.route in item.encompassingRoutes) {
+    if (item.encompassesRoute(currentBackStackEntry?.destination?.route ?: "")) {
         // already in the current home destination, no need to navigate
         return
     }

--- a/app/src/main/java/com/pedroid/qrcodecompose/androidapp/home/navigation/QRCodeAppNavHost.kt
+++ b/app/src/main/java/com/pedroid/qrcodecompose/androidapp/home/navigation/QRCodeAppNavHost.kt
@@ -10,13 +10,14 @@ import com.pedroid.qrcodecompose.androidapp.features.generate.navigation.generat
 import com.pedroid.qrcodecompose.androidapp.features.history.navigation.historyFeatureNavigationRoutes
 import com.pedroid.qrcodecompose.androidapp.features.scan.navigation.scanningFeatureNavigationRoutes
 import com.pedroid.qrcodecompose.androidapp.features.settings.navigation.settingsFeatureNavigationRoutes
+import kotlin.reflect.KClass
 
 @Composable
 fun QRCodeAppNavHost(
     navHostController: NavHostController,
     windowWidthSizeClass: WindowWidthSizeClass,
     modifier: Modifier = Modifier,
-    startDestination: String = "",
+    startDestination: KClass<*>,
 ) {
     NavHost(
         navController = navHostController,

--- a/app/src/main/java/com/pedroid/qrcodecompose/androidapp/home/presentation/HomeNavigationUI.kt
+++ b/app/src/main/java/com/pedroid/qrcodecompose/androidapp/home/presentation/HomeNavigationUI.kt
@@ -12,6 +12,7 @@ import com.pedroid.qrcodecompose.androidapp.designsystem.components.QRAppBottomN
 import com.pedroid.qrcodecompose.androidapp.designsystem.components.QRAppNavRail
 import com.pedroid.qrcodecompose.androidapp.designsystem.components.QRAppNavRailItem
 import com.pedroid.qrcodecompose.androidapp.home.navigation.HomeDestinationItem
+import com.pedroid.qrcodecompose.androidapp.home.navigation.encompassesRoute
 
 // region UI
 @Composable
@@ -71,9 +72,6 @@ private fun HomeDestinationItem.NavText() {
 // region utils
 private fun NavDestination?.isHomeItemInHierarchy(destination: HomeDestinationItem) =
     this?.hierarchy?.any {
-        destination.encompassingRoutes.any { encompassingRoute ->
-            // to make sure the item is still selected in the main navigation route or any of the subsequent navigation routes
-            it.route?.contains(encompassingRoute, ignoreCase = true) ?: false
-        }
+        destination.encompassesRoute(it.route)
     } ?: false
 // endregion utils

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,4 +8,5 @@ plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
 }

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -10,6 +10,7 @@ If you have any questions or suggestions, feel free to open an issue!
   - [Coroutines](https://kotlinlang.org/docs/coroutines-overview.html)
   - [Flows](https://kotlinlang.org/docs/flow.html)
   - [Kotlin Symbol Processing (KSP)](https://kotlinlang.org/docs/ksp-overview.html)
+  - [Serialization](https://github.com/Kotlin/kotlinx.serialization)
   - [Parcelize Plugin](https://plugins.gradle.org/plugin/org.jetbrains.kotlin.plugin.parcelize)
 - [Android Studio + Android SDK](https://developer.android.com/studio)
 - [Jetpack Compose](https://developer.android.com/develop/ui/compose)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ googleAccompanist = "0.34.0"
 kotlin = "1.9.23"
 kotlinter = "4.2.0"
 kotlinxCoroutines = "1.8.0"
+kotlinxSerialization = "1.6.3"
 junit = "4.13.2"
 hilt = "2.51"
 ksp = "1.9.23-1.0.20"
@@ -82,6 +83,7 @@ hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", v
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 mlkit-barcodescanning = { group = "com.google.mlkit", name = "barcode-scanning", version.ref = "mlkitBarcodeScanning" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 mockk-agent = { group = "io.mockk", name = "mockk-agent", version.ref = "mockk" }
@@ -98,6 +100,7 @@ com-android-library = { id = "com.android.library", version.ref = "androidGradle
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinter" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 org-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ androidxHiltNavigationCompose = "1.2.0"
 # currently androidxLifecycle 2.8.0 relies on a Beta version of compose, so won't be updating it for now
 #   see https://issuetracker.google.com/issues/336842920#comment5
 androidxLifecycle = "2.7.0"
+androidxNavigation = "2.8.0-beta02"
 androidxRoom = "2.6.1"
 androidxTestExtJunit = "1.1.5"
 androidxTestMonitor = "1.6.1"
@@ -64,6 +65,7 @@ androidx-datastore = { group = "androidx.datastore", name = "datastore", version
 androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "androidxHiltNavigationCompose" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidxNavigation" }
 androidx-room = { group = "androidx.room", name = "room-runtime", version.ref = "androidxRoom" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "androidxRoom" }
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "androidxRoom" }


### PR DESCRIPTION
With Compose Navigation 2.8.0, type safety in arguments is now supported - https://developer.android.com/guide/navigation/design/type-safety

This PR refactors the app's navigation to now be type-safe. This will become an even more useful refactor as the app gets more screens, and screens with multiple arguments.