### PR TITLE
Fix bug in generate QR Code

### DIFF
--- a/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/generate/presentation/GenerateQRCodeScreen.kt
+++ b/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/generate/presentation/GenerateQRCodeScreen.kt
@@ -325,9 +325,9 @@ private fun QRCodeActionButtons(actionListeners: GenerateQRCodeActionListeners =
  */
 @Composable
 private fun rememberActionButtonsTransparency(state: GenerateQRCodeContentState): State<Float> =
-    remember(key1 = state.generating.qrCodeText) {
+    remember(key1 = state.canGenerate) {
         derivedStateOf {
-            if (!state.generating.empty) 1f else 0f
+            if (state.canGenerate) 1f else 0f
         }
     }
 // endregion screen composables


### PR DESCRIPTION
## Fixed the following bug

Action buttons still visible when switching to invalid format

### Steps to reproduce:

1. Go to generate
2. Type some random text to generate a QR Code
3. Switch to a format for numeric barcodes, e.g. UPC-A
4. **BUG:** The action buttons to save, share or copy QR Code are still visible, even though the barcode text is not valid and not being displayed

### Video of the bug

https://github.com/pedro-mgb/mini_qr_code/assets/47814970/e4fa7f95-a490-4289-bdea-aead927e6278
