### PR TITLE
fix: Proguard crash

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -25,3 +25,5 @@
 -keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite* {
    <fields>;
 }
+# to not crash due to missing compose navigation type-safe mapping.
+-keep class com.pedroid.qrcodecomposelib.common.QRCodeComposeXFormat


### PR DESCRIPTION
Fix Proguard crash for type-safe navigation argument map.

The fix for https://issuetracker.google.com/issues/346475493 was (partially apparently) addressed in https://github.com/pedro-mgb/mini_qr_code/blob/main/app/src/main/java/com/pedroid/qrcodecompose/androidapp/features/generate/navigation/customize/format/QRCodeFormatSelectionNavigation.kt#L30

However it crashes in a build optimized with proguard/R8. Adding an exception to the proguard file fixes the crash.

